### PR TITLE
Add section grouping functionality to navigation webpart

### DIFF
--- a/NAVIGATION_SETUP.md
+++ b/NAVIGATION_SETUP.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-A SharePoint Framework (SPFx) webpart that displays navigation links from a SharePoint list organized by sections. The webpart groups navigation items by section headers, displaying links separated by slashes with 6 items per line within each section. Each link comes from a SharePoint list with configurable "Display Text", "Link", and "Section" columns.
+A SharePoint Framework (SPFx) webpart that displays navigation links from a SharePoint list organized by sections. The webpart groups navigation items by section headers, displaying links separated by slashes with 6 items per line within each section. Each section displays its name as a prominent header. Navigation data comes from a SharePoint list with configurable "Display Text", "Link", and "Section" columns.
 
 ![SharePoint Framework Version](https://img.shields.io/badge/version-1.20.0-green.svg)
 
@@ -10,8 +10,7 @@ A SharePoint Framework (SPFx) webpart that displays navigation links from a Shar
 
 - **Section Grouping**: Automatically groups navigation items by section
 - **Dynamic List Selection**: Choose any SharePoint list from the current site
-- **Configurable Header**: Set custom header text for the entire navigation
-- **Section Headers**: Each section displays its own header with visual separation
+- **Section Headers**: Each section displays its name as a prominent header (24px font size)
 - **Slash-Separated Links**: Navigation links displayed with slash separators (no styling)
 - **Responsive Layout**: 6 navigation items per line within each section, automatically wrapping
 - **Property Pane Integration**: Easy configuration with dropdown list selection
@@ -92,13 +91,12 @@ Create a SharePoint list with the following columns:
    - Edit a SharePoint page
    - Add the "SP Navigation Section" webpart
    - Configure the webpart properties:
-     - **Header Text**: Enter the title for your navigation section
      - **Select Navigation List**: Choose your navigation list from the dropdown
      - Use quick links to create new list or view selected list
 
 3. **Customize Appearance**
    - Navigation items are automatically grouped by section
-   - Each section displays a header with a bottom border
+   - Each section displays its name as a prominent header
    - Within each section, items display 6 per line
    - Links are separated by forward slashes
    - Sections are sorted alphabetically
@@ -117,12 +115,6 @@ Edit `src/webparts/spNavigationSection/components/SpNavigationSection.module.scs
 // Apply to main container
 .spNavigationSection {
   font-family: 'Roboto', Arial, sans-serif;
-}
-
-// Apply to header specifically
-.header {
-  font-family: 'Roboto', Arial, sans-serif;
-  font-weight: 700;
 }
 
 // Apply to section headers
@@ -190,7 +182,6 @@ gulp package-solution --ship
 
 | Property | Type | Description |
 |----------|------|-------------|
-| description | string | Header text displayed above navigation sections |
 | selectedListId | string | GUID of the selected SharePoint list |
 
 ## Technical Implementation
@@ -214,6 +205,7 @@ gulp package-solution --ship
 |---------|------|----------|
 | 1.0.0 | 2025-06-22 | Initial navigation webpart implementation |
 | 2.0.0 | 2025-06-23 | Added section grouping functionality |
+| 2.1.0 | 2025-06-23 | Removed header text property, section headers are now main headers |
 
 ## Authors
 

--- a/NAVIGATION_SETUP.md
+++ b/NAVIGATION_SETUP.md
@@ -2,16 +2,18 @@
 
 ## Summary
 
-A SharePoint Framework (SPFx) webpart that displays navigation links from a SharePoint list. The webpart shows navigation items as clickable links separated by slashes, with 6 items per line. Each link comes from a SharePoint list with configurable "Display Text" and "Link" columns.
+A SharePoint Framework (SPFx) webpart that displays navigation links from a SharePoint list organized by sections. The webpart groups navigation items by section headers, displaying links separated by slashes with 6 items per line within each section. Each link comes from a SharePoint list with configurable "Display Text", "Link", and "Section" columns.
 
 ![SharePoint Framework Version](https://img.shields.io/badge/version-1.20.0-green.svg)
 
 ## Features
 
+- **Section Grouping**: Automatically groups navigation items by section
 - **Dynamic List Selection**: Choose any SharePoint list from the current site
-- **Configurable Header**: Set custom header text for the navigation section
+- **Configurable Header**: Set custom header text for the entire navigation
+- **Section Headers**: Each section displays its own header with visual separation
 - **Slash-Separated Links**: Navigation links displayed with slash separators (no styling)
-- **Responsive Layout**: 6 navigation items per line, automatically wrapping
+- **Responsive Layout**: 6 navigation items per line within each section, automatically wrapping
 - **Property Pane Integration**: Easy configuration with dropdown list selection
 - **Quick Actions**: Direct links to create new lists or view selected list
 - **Custom Font Support**: Built-in directions for implementing custom fonts
@@ -25,17 +27,22 @@ Create a SharePoint list with the following columns:
 | Title | Single line of text | Default SharePoint title column |
 | Display Text | Single line of text | Text to display for the navigation link |
 | Link | Hyperlink or Single line of text | URL for the navigation link |
+| Section | Choice | Section grouping for the navigation item |
 
 ### Sample List Data:
 
-| Title | Display Text | Link |
-|-------|-------------|------|
-| Home | Home | https://contoso.sharepoint.com |
-| About | About Us | https://contoso.sharepoint.com/about |
-| Services | Our Services | https://contoso.sharepoint.com/services |
-| Contact | Contact | https://contoso.sharepoint.com/contact |
-| Blog | Company Blog | https://contoso.sharepoint.com/blog |
-| Careers | Join Us | https://contoso.sharepoint.com/careers |
+| Title | Display Text | Link | Section |
+|-------|-------------|------|---------|
+| Home | Home | https://contoso.sharepoint.com | Main Navigation |
+| About | About Us | https://contoso.sharepoint.com/about | Main Navigation |
+| Services | Our Services | https://contoso.sharepoint.com/services | Main Navigation |
+| Contact | Contact | https://contoso.sharepoint.com/contact | Main Navigation |
+| HR Portal | Human Resources | https://contoso.sharepoint.com/hr | Employee Resources |
+| IT Support | IT Help Desk | https://contoso.sharepoint.com/it | Employee Resources |
+| Benefits | Employee Benefits | https://contoso.sharepoint.com/benefits | Employee Resources |
+| Training | Training Portal | https://contoso.sharepoint.com/training | Employee Resources |
+| Blog | Company Blog | https://contoso.sharepoint.com/blog | News & Updates |
+| Announcements | Latest News | https://contoso.sharepoint.com/news | News & Updates |
 
 ## Installation & Setup
 
@@ -51,7 +58,7 @@ Create a SharePoint list with the following columns:
    ```bash
    git clone https://github.com/przemekbok/sp-navigation-section.git
    cd sp-navigation-section
-   git checkout feature/navigation-webpart
+   git checkout feature/section-grouping
    ```
 
 2. **Install dependencies**
@@ -75,8 +82,11 @@ Create a SharePoint list with the following columns:
 1. **Create Navigation List**
    - Go to your SharePoint site
    - Create a new list (or use the "Create New List" link in webpart properties)
-   - Add the required columns: "Display Text" and "Link"
-   - Add your navigation items
+   - Add the required columns:
+     - **Display Text** (Single line of text)
+     - **Link** (Hyperlink or Single line of text)
+     - **Section** (Choice column with your section names)
+   - Add your navigation items with appropriate section assignments
 
 2. **Add WebPart to Page**
    - Edit a SharePoint page
@@ -87,9 +97,11 @@ Create a SharePoint list with the following columns:
      - Use quick links to create new list or view selected list
 
 3. **Customize Appearance**
-   - The webpart automatically displays 6 navigation items per line
+   - Navigation items are automatically grouped by section
+   - Each section displays a header with a bottom border
+   - Within each section, items display 6 per line
    - Links are separated by forward slashes
-   - No special styling is applied to maintain clean appearance
+   - Sections are sorted alphabetically
 
 ## Custom Font Usage
 
@@ -111,6 +123,12 @@ Edit `src/webparts/spNavigationSection/components/SpNavigationSection.module.scs
 .header {
   font-family: 'Roboto', Arial, sans-serif;
   font-weight: 700;
+}
+
+// Apply to section headers
+.sectionHeader {
+  font-family: 'Roboto', Arial, sans-serif;
+  font-weight: 600;
 }
 
 // Apply to navigation links
@@ -172,7 +190,7 @@ gulp package-solution --ship
 
 | Property | Type | Description |
 |----------|------|-------------|
-| description | string | Header text displayed above navigation items |
+| description | string | Header text displayed above navigation sections |
 | selectedListId | string | GUID of the selected SharePoint list |
 
 ## Technical Implementation
@@ -194,7 +212,8 @@ gulp package-solution --ship
 
 | Version | Date | Comments |
 |---------|------|----------|
-| 1.0.0 | 2025-05-27 | Initial navigation webpart implementation |
+| 1.0.0 | 2025-06-22 | Initial navigation webpart implementation |
+| 2.0.0 | 2025-06-23 | Added section grouping functionality |
 
 ## Authors
 

--- a/src/webparts/spNavigationSection/SpNavigationSectionWebPart.ts
+++ b/src/webparts/spNavigationSection/SpNavigationSectionWebPart.ts
@@ -3,7 +3,6 @@ import * as ReactDom from 'react-dom';
 import { Version } from '@microsoft/sp-core-library';
 import {
   type IPropertyPaneConfiguration,
-  PropertyPaneTextField,
   PropertyPaneDropdown,
   PropertyPaneLink,
   IPropertyPaneDropdownOption
@@ -17,7 +16,6 @@ import SpNavigationSection from './components/SpNavigationSection';
 import { ISpNavigationSectionProps, INavigationItem, INavigationSection, IListInfo } from './components/ISpNavigationSectionProps';
 
 export interface ISpNavigationSectionWebPartProps {
-  description: string;
   selectedListId: string;
 }
 
@@ -34,7 +32,6 @@ export default class SpNavigationSectionWebPart extends BaseClientSideWebPart<IS
     const element: React.ReactElement<ISpNavigationSectionProps> = React.createElement(
       SpNavigationSection,
       {
-        description: this.properties.description,
         isDarkTheme: this._isDarkTheme,
         environmentMessage: this._environmentMessage,
         hasTeamsContext: !!this.context.sdks.microsoftTeams,
@@ -80,9 +77,6 @@ export default class SpNavigationSectionWebPart extends BaseClientSideWebPart<IS
         this.render();
         this.context.propertyPane.refresh();
       });
-    } else if (propertyPath === 'description' && newValue !== oldValue) {
-      this.properties.description = newValue;
-      this.render();
     }
   }
 
@@ -337,10 +331,6 @@ export default class SpNavigationSectionWebPart extends BaseClientSideWebPart<IS
             {
               groupName: 'Navigation Settings',
               groupFields: [
-                PropertyPaneTextField('description', {
-                  label: 'Header Text',
-                  placeholder: 'Enter header text...'
-                }),
                 PropertyPaneDropdown('selectedListId', {
                   label: 'Select Navigation List',
                   options: listOptions,

--- a/src/webparts/spNavigationSection/components/ISpNavigationSectionProps.ts
+++ b/src/webparts/spNavigationSection/components/ISpNavigationSectionProps.ts
@@ -5,15 +5,21 @@ export interface ISpNavigationSectionProps {
   hasTeamsContext: boolean;
   userDisplayName: string;
   selectedListId: string;
-  navigationItems: INavigationItem[];
+  navigationSections: INavigationSection[];
   siteUrl: string;
   isLoading: boolean;
   errorMessage: string;
 }
 
+export interface INavigationSection {
+  section: string;
+  items: INavigationItem[];
+}
+
 export interface INavigationItem {
   displayText: string;
   link: string;
+  section: string;
 }
 
 export interface IListInfo {

--- a/src/webparts/spNavigationSection/components/ISpNavigationSectionProps.ts
+++ b/src/webparts/spNavigationSection/components/ISpNavigationSectionProps.ts
@@ -1,5 +1,4 @@
 export interface ISpNavigationSectionProps {
-  description: string;
   isDarkTheme: boolean;
   environmentMessage: string;
   hasTeamsContext: boolean;

--- a/src/webparts/spNavigationSection/components/SpNavigationSection.module.scss
+++ b/src/webparts/spNavigationSection/components/SpNavigationSection.module.scss
@@ -32,6 +32,37 @@
   // font-family: 'Roboto', Arial, sans-serif;
 }
 
+// Sections container
+.sectionsContainer {
+  margin-top: 20px;
+}
+
+// Individual section container
+.navigationSectionContainer {
+  margin-bottom: 30px;
+  
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+// Section header styling
+.sectionHeader {
+  margin: 0 0 15px 0;
+  padding: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: "[theme:neutralPrimary, default: #323130]";
+  color: var(--neutralPrimary);
+  text-align: center;
+  border-bottom: 2px solid "[theme:neutralLight, default: #edebe9]";
+  border-bottom: 2px solid var(--neutralLight);
+  padding-bottom: 8px;
+  
+  // CUSTOM FONT FOR SECTION HEADERS EXAMPLE:
+  // font-family: 'Roboto', Arial, sans-serif;
+}
+
 .navigationContent {
   line-height: 2.0; // Increased line height for better spacing with larger text
   font-size: 18px; // Increased base font size for navigation area
@@ -50,6 +81,7 @@
   
   &:last-child {
     margin-right: 0;
+    margin-bottom: 0;
   }
 }
 

--- a/src/webparts/spNavigationSection/components/SpNavigationSection.module.scss
+++ b/src/webparts/spNavigationSection/components/SpNavigationSection.module.scss
@@ -19,22 +19,9 @@
   }
 }
 
-.header {
-  margin: 0 0 20px 0;
-  padding: 0;
-  font-size: 24px;
-  font-weight: 600;
-  color: "[theme:neutralPrimary, default: #323130]";
-  color: var(--neutralPrimary);
-  text-align: center; // Center the header text
-  
-  // CUSTOM FONT FOR HEADER EXAMPLE:
-  // font-family: 'Roboto', Arial, sans-serif;
-}
-
 // Sections container
 .sectionsContainer {
-  margin-top: 20px;
+  margin-top: 0;
 }
 
 // Individual section container
@@ -46,18 +33,15 @@
   }
 }
 
-// Section header styling
+// Section header styling - now the main header style
 .sectionHeader {
-  margin: 0 0 15px 0;
+  margin: 0 0 20px 0;
   padding: 0;
-  font-size: 20px;
+  font-size: 24px;
   font-weight: 600;
   color: "[theme:neutralPrimary, default: #323130]";
   color: var(--neutralPrimary);
   text-align: center;
-  border-bottom: 2px solid "[theme:neutralLight, default: #edebe9]";
-  border-bottom: 2px solid var(--neutralLight);
-  padding-bottom: 8px;
   
   // CUSTOM FONT FOR SECTION HEADERS EXAMPLE:
   // font-family: 'Roboto', Arial, sans-serif;
@@ -298,4 +282,18 @@
       color: var(--linkHovered);
     }
   }
+}
+
+// Legacy header class (no longer used but kept for backward compatibility)
+.header {
+  margin: 0 0 20px 0;
+  padding: 0;
+  font-size: 24px;
+  font-weight: 600;
+  color: "[theme:neutralPrimary, default: #323130]";
+  color: var(--neutralPrimary);
+  text-align: center;
+  
+  // CUSTOM FONT FOR HEADER EXAMPLE:
+  // font-family: 'Roboto', Arial, sans-serif;
 }

--- a/src/webparts/spNavigationSection/components/SpNavigationSection.tsx
+++ b/src/webparts/spNavigationSection/components/SpNavigationSection.tsx
@@ -1,21 +1,20 @@
 import * as React from 'react';
 import styles from './SpNavigationSection.module.scss';
-import type { ISpNavigationSectionProps } from './ISpNavigationSectionProps';
+import type { ISpNavigationSectionProps, INavigationSection } from './ISpNavigationSectionProps';
 import { escape } from '@microsoft/sp-lodash-subset';
 
 export default class SpNavigationSection extends React.Component<ISpNavigationSectionProps> {
   
-  private renderNavigationItems(): React.ReactElement[] {
-    const { navigationItems } = this.props;
+  private renderNavigationItems(items: any[]): React.ReactElement[] {
     const elements: React.ReactElement[] = [];
     
-    if (!navigationItems || navigationItems.length === 0) {
+    if (!items || items.length === 0) {
       return [];
     }
 
     // Group items into chunks of 6
-    for (let i = 0; i < navigationItems.length; i += 6) {
-      const chunk = navigationItems.slice(i, i + 6);
+    for (let i = 0; i < items.length; i += 6) {
+      const chunk = items.slice(i, i + 6);
       const navigationLine = this.createNavigationLine(chunk, i);
       elements.push(navigationLine);
     }
@@ -57,8 +56,29 @@ export default class SpNavigationSection extends React.Component<ISpNavigationSe
     );
   }
 
+  private renderSections(): React.ReactElement[] {
+    const { navigationSections } = this.props;
+    
+    if (!navigationSections || navigationSections.length === 0) {
+      return [];
+    }
+
+    return navigationSections.map((section: INavigationSection, sectionIndex: number) => {
+      const navigationElements = this.renderNavigationItems(section.items);
+      
+      return (
+        <div key={`section-${sectionIndex}`} className={styles.navigationSectionContainer}>
+          <h3 className={styles.sectionHeader}>{escape(section.section)}</h3>
+          <div className={styles.navigationContent}>
+            {navigationElements}
+          </div>
+        </div>
+      );
+    });
+  }
+
   private renderContent(): React.ReactElement {
-    const { isLoading, errorMessage, navigationItems, selectedListId } = this.props;
+    const { isLoading, errorMessage, navigationSections, selectedListId } = this.props;
 
     if (isLoading) {
       return (
@@ -79,7 +99,7 @@ export default class SpNavigationSection extends React.Component<ISpNavigationSe
               <strong>Troubleshooting tips:</strong>
               <ul>
                 <li>Ensure the list has items</li>
-                <li>Create columns named &quot;Display Text&quot; and &quot;Link&quot;</li>
+                <li>Create columns named &quot;Display Text&quot;, &quot;Link&quot;, and &quot;Section&quot;</li>
                 <li>Check that you have permission to read the list</li>
               </ul>
             </div>
@@ -99,7 +119,7 @@ export default class SpNavigationSection extends React.Component<ISpNavigationSe
       );
     }
 
-    if (!navigationItems || navigationItems.length === 0) {
+    if (!navigationSections || navigationSections.length === 0) {
       return (
         <div className={styles.noItems}>
           <div className={styles.noItemsIcon}>📋</div>
@@ -107,16 +127,16 @@ export default class SpNavigationSection extends React.Component<ISpNavigationSe
             No navigation items found in the selected list.
           </div>
           <div className={styles.noItemsHelp}>
-            Add items to your list with &quot;Display Text&quot; and &quot;Link&quot; columns.
+            Add items to your list with &quot;Display Text&quot;, &quot;Link&quot;, and &quot;Section&quot; columns.
           </div>
         </div>
       );
     }
 
-    const navigationElements = this.renderNavigationItems();
+    const sectionElements = this.renderSections();
     return (
-      <div className={styles.navigationContent}>
-        {navigationElements}
+      <div className={styles.sectionsContainer}>
+        {sectionElements}
       </div>
     );
   }

--- a/src/webparts/spNavigationSection/components/SpNavigationSection.tsx
+++ b/src/webparts/spNavigationSection/components/SpNavigationSection.tsx
@@ -68,7 +68,7 @@ export default class SpNavigationSection extends React.Component<ISpNavigationSe
       
       return (
         <div key={`section-${sectionIndex}`} className={styles.navigationSectionContainer}>
-          <h3 className={styles.sectionHeader}>{escape(section.section)}</h3>
+          <h2 className={styles.sectionHeader}>{escape(section.section)}</h2>
           <div className={styles.navigationContent}>
             {navigationElements}
           </div>
@@ -142,16 +142,10 @@ export default class SpNavigationSection extends React.Component<ISpNavigationSe
   }
 
   public render(): React.ReactElement<ISpNavigationSectionProps> {
-    const {
-      description,
-      hasTeamsContext
-    } = this.props;
+    const { hasTeamsContext } = this.props;
 
     return (
       <section className={`${styles.spNavigationSection} ${hasTeamsContext ? styles.teams : ''}`}>
-        {description && (
-          <h2 className={styles.header}>{escape(description)}</h2>
-        )}
         {this.renderContent()}
       </section>
     );


### PR DESCRIPTION
## Summary
This PR adds section grouping functionality to the navigation webpart. Navigation items can now be organized into sections using a "Section" choice column in the SharePoint list.

## Changes Made
- Added support for a "Section" column (choice type) in SharePoint lists
- Updated interfaces to support section grouping
- Modified data loading to read and process the Section column
- Implemented grouping logic to organize items by section
- Updated React component to render sections with headers
- Added styling for section headers with visual separation
- Updated documentation to reflect the new functionality

## Features
- Navigation items are automatically grouped by their section value
- Each section displays a header with a bottom border for visual separation
- Sections are sorted alphabetically
- Within each section, items maintain the 6-per-line layout with slash separators
- Items without a section value default to "General" section

## Testing
1. Create a SharePoint list with the required columns (Display Text, Link, Section)
2. Add the Section column as a Choice type with your desired section names
3. Add navigation items with different section values
4. Deploy the webpart and verify sections are displayed correctly

## Screenshots
The webpart now groups navigation items by section, with each section having its own header.

## Breaking Changes
None - the webpart is backward compatible. If no Section column exists, all items will be grouped under a default "General" section.